### PR TITLE
Use te reo Māori translation from PDF

### DIFF
--- a/data/udhr/udhr_mri.xml
+++ b/data/udhr/udhr_mri.xml
@@ -3,81 +3,80 @@
 <udhr iso639-3='mri' xml:lang='mi' key='mri' n='Maori' dir='ltr' iso15924='Latn' xmlns="http://efele.net/udhr">
   <title>WHAKAPUAKITANGA WHANUI O NGA MANA O TE TANGATA - 1948</title>
   <preamble>
-    <para>No te mea na te whakanoa a na te whakahawea ki nga mana o te tangata i tupu ai nga mahi whakarihariha i pouri ai te ngakau tangata, a ko te kohaetanga o tetahi ao hou e mahorahora ai te tangata ki te korero ki te whakapono, ki te noho noa i runga i te rangimarie a i te ora, kua panuitia hei taumata mo te koingotanga o te ngakau o te mano tini o te tangata.</para>
-    <para>No te mea ki te kore te tangata ae akina kia tae ki te tino hemanawatanga kia hapai hoki i te pakanga hei turaki i te mana tukino hei pehi hoki i te iwi, he mea tika rawa kia tiakina nga mana o te tangata i raro i tenga ritenga o te ture.</para>
-    <para>No te mea he mea tika rawa kia hapainga nga ritenga e tupu ai nga whakaaro whakawhanaunga i waenganui i nga iwi o te ao.</para>
-    <para>No te mea ko nga iwi o te Kotahitanga kua whakaatu ki roto i te Kawenata i te tino whakapumautanga o to ratou whakapono mo te kaupapa o nga mana motuhake o te tangata, mo te ihi me te wana o te tinana tangata, a mo nga tika tauriterite o te tane me te wahine, a kua whakarite tikanga hoki kia hapainga nga ritenga toko i te ora me te whakapiki i nga ahuatanga o te oranga i tenei ao i roto i te rangatiratanga whanui.</para>
-    <para>No te mea ko nga iwi o roto i tenei Kotahitanga kua oati i runga i te whakaaro kotahi kotaki ki te hapai i te ritenga whanui o te whakanui me te pupuri i nga tika o te tangata me nga kaupapa tuturu o nga rangatiratanga o te ora i tenei ao.</para>
-    <para>No te mea e tutaki ai tenei oati he mea nui rawa kia matou te mano tini o te tangata ki enei tikanga rangatira.</para>
-    <para>No reira inaianei: ko te Huihuinga Topu o Te Kotahitanga o Nga Iwi o Te Ao.</para>
-    <para>Ka Paanui</para>
-    <para>I Tenei Whakapuakitanga Whanui O Nga Mana O Te Tangata.</para>
-    <para>Ka meinga nei hei tauira whanui mo nga tikanga hei whainga kia tutaki i te katoa o nga iwi i runga i te whai a tena tangata a tena tangata me nga ropu katoa o roto i nga whakahaere me te pupuri tonu i nga wa katoa i roto i te hinengaro i tenei Whakapuakitanga, me whakapau i te kaha i runga i te ritenga tohutohu me te ako ki te hapai i nga tikanga rangatira: a ma runga hoki i nga whakaritenga e ahu whakamua ana a ia iwi puta noa te ao, kia mau ai te tuturutanga ki te katoa, o te pono o te pupuri me te whakarite i enei ritenga i waenganui o nga iwi o roto i te kotahitanga, hui tahi atu ki nga iwi o nga whenua kei raro i o ratou mana whakahaere.</para>
+    <para>I runga i te mōhio ko te whakapūmau i te mana o ngā tāngata katoa o te ao, i te ōritetanga hoki o ō rātau tika e kore e taea te wewete, koia ko te tūāpapa o te noho herekore i roto i te ture me te maungarongo i te ao,</para>
+    <para>I runga i te mōhio nā te aro kore me te whakaparahako i ngā tika tangata ka hua mai ai he tino mahi tūkino e oho kino nei te mauri tangata, ā, kua huaina mai e te iwi whānui ko te tino whāinga ko te putanga mai o tētahi ao e taea ana e te tangata te kōrero herekore, te whakapono herekore, ā, e wātea ana i te mataku me te korekai,</para>
+    <para>I runga i te mōhio me āta tiaki i ngā tika tangata ki roto i te ture e kore ai te tangata e mate ki te huri ki te whawhai i ngā mahi takahī mana, takahī tāngata,</para>
+    <para>I runga i te mōhio me āta whakatairanga te whakawhanaungatanga ki waenga i ngā whenua o te ao,</para>
+    <para>I runga i te mōhio kua oti i ngā iwi o Te Kotahitanga o Te Ao, ki roto i tōna kaupapa, te whakapūmau i tō rātau whakapono ki ngā tika taketake o te tangata, ki te mana me te tapu o te tangata, ki te ōritetanga o te mana tāne me te mana wahine, ā, kua whakatau rātau ki te whai kia whakapikia ngā āhuatanga oranga ki roto i te whānuitanga o te noho herekore,</para>
+    <para>I runga i te mōhio kua kī taurangi ngā Mana Whenua o Te Kotahitanga o te Ao ka whāia e rātau te kaupapa whakanui, whakatinana hoki i ngā tika tangata me ngā herekoretanga taketake, i runga i te mahi tahi ki Te Kotahitanga o Te Ao,</para>
+    <para>I runga i te mōhio ko te mea tino nui rawa atu e tino tutuki ai tēnei kī taurangi, ko te mōhiotanga ki ēnei tika me ēnei herekoretanga,</para>
+    <para>Nā konei, ka whakatau Te Rūnanga Nui ko tēnei WHAKAPUAKITANGA WHĀNUI O NGĀ TIKA TANGATA te taumata hei whakatutuki mō ngā iwi me ngā whenua katoa, e taea ai e ia tangata me ia rōpū o te hapori, i runga i te whai whakaaro ki tēnei Whakapuakitanga i ngā wā katoa, te whakatairanga i te whakaaro nui ki ēnei tika me ēnei herekoretanga mā te whakaako me te tuku mātauranga, ā, mā ngā huarahi kōkiri ki roto i te whenua, ki waenga hoki i ngā whenua o te ao, e mana ai te whakapūmautanga me te whakatinanatanga ki waenga i ngā iwi o ngā Mana Whenua me ngā iwi o ngā rohe kei raro i ō rātau maru.
+</para>
   </preamble>
   <article number="1">
     <title>Rarangi 1</title>
-    <para>Ko te katoa o nga tangata i te whanaungatanga mai e watea ana i nga here katoa; e tauriterite ana hoki nga mana me nga tika. E whakawhiwhia ana hoki ki a ratou te ngakau whai whakaaro me te hinengaro mohio ki te tika me te he, a e tika ana kia meinga te mahi a tetahi ki tetahi me ma roto atu i te wairua o te noho tahi, ano he teina he tuakana i ringa i te whakaaro kotahi.</para>
+    <para>I te whānautanga mai o te tangata, kāhore ōna here, e ōrite ana tōna mana me ōna tika ki te katoa. Ka whakatōkia ki roto i te tangata he wairua,
+he hinengaro hoki, ā, me mahi tahi ia ki ngā tāngata o te ao i runga i te āhua o te tuakana me te teina.</para>
   </article>
   <article number="2">
     <title>Rarangi 2</title>
-    <para>E whai mana ana ia tangata kia whiwhi ki te katoa o nga rangatiratanga me nga huarahi whanui o te ao e whakakaupapatia nei i roto i tenei Whakapuakitanga, kaua e araitia ahakoa pewhea, ara i runga i enei ahuatanga e whai ake nei, i te mea he iwi ke, i te ahua kua kiri ke, i te tanetanga i te wahinetanga, i te reo, i te whakapono, i te awhina ropu whakaara ture i tetahi atu kaupapa whakaaro ranei, ahakoa no roto mai i te iwi whanui no tetahi ropu ranei, no te kaupapa pupuri taonga, no te whanaungatanga mai, no tetahi tunga whai-tikanga ranei</para>
-    <para>He apiti atu ki enei, kaua e meinga hei ritenga wehewehe te mea i whakakaupapatia na runga i nga whakahaere ture, i nga mana whanui ranei o te ao kua whakawhiwhia ki tetahi whenua ki tetahi wahanga whenua ranei no reira nei tetahi tangata, ahakoa taua wahanga whenua he whai mana motuhake, kei raro ranei i te Kaitiakitanga, he takiwa whenua ranei kahore nei ona Mana Kawanatanga Motuhake, kei raro ranei i tetahi atu ritenga whakawhaiti i tona mana motuhake.</para>
+    <para>E āhei ana ia tangata ki ngā tika me ngā herekoretanga e rārangi mai nei ki tēnei Whakapuakitanga, kāhore nei he rerekētanga ā-iwi, ā-kiri, ā-ira, ā-reo, ā-whakapono, ā- tōrangapū, ā-whenua, ā-whai rawa, ā-whānautanga, ā-aha nei. Hei āpiti atu, kāhore nei he rerekētanga e pā ki te tangata nā runga i te āhua tōrangapū o te whenua e noho nei ia, i te āhua ā-ture rānei, i te tūranga rānei o taua whenua ki waenga i ngā whenua o te ao, ahakoa he whenua tū motuhake, he whenua e tiakina ana e tētahi atu, he whenua rānei e herea nei tōna rangatiratanga.</para>
   </article>
   <article number="3">
     <title>Rarangi 3</title>
-    <para>Ko ia tangata e whai take ana ki te mauri ora, me watea i nga tikanga tere, me maru hoki ia i raro i te mana o te ture.</para>
+    <para>E whai tika ana ia tangata ki te ora, ki te noho herekore, ki te haumarutanga o te tinana.</para>
   </article>
   <article number="4">
     <title>Rarangi 4</title>
-    <para>Kaua tetahi tangata e noho pononga a ko nga tikanga whakapononga i te tangata me takahi rawa atu.</para>
+    <para>Kia kaua te tangata e pupuritia hei taurekareka, hei pononga mā tētahi, ā, me aukati ngā āhuatanga katoa o te whakataurekareka i te tangata, o te hoko rānei i te tangata hei taurekareka.</para>
   </article>
   <article number="5">
     <title>Rarangi 5</title>
-    <para>Kaua tetahi tangata e whakamamae noatia e tukua ranei ki nga tikanga whakaiti me nga whiu kahore nei i tika mo te tangata.</para>
+    <para>Kia kaua te tangata e tukuna kia tūkinotia, kia whiua rānei ki te mahi whakawiri, whakāhawea rānei i a ia.</para>
   </article>
   <article number="6">
     <title>Rarangi 6</title>
-    <para>Ko ia tangata e whai mana ana kia mohiotia ki nga wahi katoa he tangata ano ia i te aroaro o te ture.</para>
+    <para>E whai tika ana ia tangata kia mōhiotia hei tangata ki mua i te aroaro o te ture.</para>
   </article>
   <article number="7">
     <title>Rarangi 7</title>
-    <para>E tauriterite ana te katoa ki te aroaro o te ture a e tika ana kia tiakina e te ture, kaua he rereketanga mo tetahi i tetahi. E tika ana te katoa kia rite te tiakina kei kapea e tetahi tikanga e takahi ana i tenei whakapuakitanga, a e tetahi tikanga ranei e whakatara ana kia pera.</para>
+    <para>He ōrite ngā tāngata katoa ki mua i te aroaro o te ture, ā, e āhei ana ngā haumarutanga katoa o te ture ki a rātau i runga i te kore rerekētanga ki ētahi atu. E whai tika ana ngā tāngata katoa kia haumarutia rātau i ngā mahi whakatoihara e takahī nei i tēnei Whakapuakitanga, i ngā mahi rānei e akiaki ana kia pērā te whakatoihara.</para>
   </article>
   <article number="8">
     <title>Rarangi 8</title>
-    <para>Ko ia tangata e whai take ana kia whiwhi ki tetahi rongoa totika o te ture i na roto mai i nga Kooti Whakawa whai mana mo nga mahi e takahi ana i te tino ritenga o nga mana kua whakaputaina ki a ia e te kaupapa e te ture ranei.</para>
+    <para>E whai tika ana ia tangata ki ngā huarahi whakatikatika hapa ki mua i ngā taraipiunara tōtika o te whenua e noho nei ia mō ngā mahi e takahī ana i ngā tika taketake nā te ture i tuku.</para>
   </article>
   <article number="9">
     <title>Rarangi 9</title>
-    <para>Kaua tetahi tangata e hopukia noatia e te ringa o te ture e puritia noatia ranei i roto i tetahi whare herehere e peia noatia ranei ki tetahi whenua ke.</para>
+    <para>Kia kaua te tangata e hopukina pokanoatia, e mauheretia pokanoatia rānei, e panaia pokanoatia rānei i te whenua.</para>
   </article>
   <article number="10">
     <title>Rarangi 10</title>
-    <para>Ko ia tangata e tika ana kia whakatuturutia ki a ia tetahi whakawa tika ki te aroaro o te katoa e tetahi runanga wehekore whakahoahoa ranei, mo runga i te whakataunga i ona tika me nga tikanga hei whakarite mana tae atu hoki ki nga whakapae mona tera kua hara kino ia i raro i te ture.</para>
+    <para>E whai tika ana ia tangata kia whakawākia ōna tika me ōna kawenga, me ngā whakawhiu ā- ture e whiua nei ki a ia, ki mua i tētahi taraipiunara tū motuhake, matatika e tika ana āna whakahaere ki mua i te iwi whānui.</para>
   </article>
   <article number="11">
     <title>Rarangi 11</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata kua whapaea mo tetahi hara e ahei nei whiu e tika ana kia ki ia kahore ia i hara tae noa ki te wa e whakataua ai ae i hara ia e ai ki ta te ture i roto i tetahi whakawatanga i te aroaro o te katoa a i reira i whiwhi ia i te katoa o nga huarahi karo, tautoko hoki i a ia.</para>
+	<para>E whai tika ana ia tangata e whiua ana ki te ture kia kīia he harakore, kia oti rā anō te āta whakatau e hara ana ia ki roto i tētahi whakawākanga e puare ana, ā, kua whakawhiwhia te tangata e whakapaetia ana ki ngā momo āwhina katoa e tika ana ki a ia.</para>
       </listitem>
       <listitem>
-	<para>Kaua tetahi tangata e kiia kua hara mo runga mo tetahi hara e ahei nei kia whiua na runga na tetahi mahi i mahia, na tetahi mea ranei kihai i mahia e ia kaore nei e tika ana kia meinga he hara i raro i te ture o tetahi whenua i te ture ranei o te ao whanui i te wa o taua hara. Kaua hoki tetahi whiu e utaina atu ki te whiu e meinga ana mo taua te hara i taua wa.</para>
+	<para>Kia kaua tētahi tangata e kīia kei te noho hara ia mō tētahi mahi, mō te kore mahi rānei, mehemea ehara tērā āhuatanga i te mahi hara i te wā i mahia ai te mahi, i kore ai rānei i mahia. Kia kaua hoki e utaina ki te tangata he whakawhiu e taimaha ake ana i tērā e mana ana i te wā o te mahi hara.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="12">
     <title>Rarangi 12</title>
-    <para>Kaua tetahi tangata e whakararuraru pokonoatia, tana whanau, tona kainga, ana pukapuka ranei, e takahi ranei i tona ingoa nui me tona ingoa pai. Ko ia tangata e ahei ana ma te ture e tiaki kei pa enei ahua whakararu me enei tukinotanga.</para>
+    <para>Kia kaua e whakararurarua pokanoa te noho motuhake a te tangata, tōna whanau, tōna kāinga me āna tuhinga, kia kaua hoki e takahia tōna mana me tōna ingoa pai. E whai tika ana ia tangata ki te haumarutanga o te ture i ngā momo karawhiu nei.</para>
   </article>
   <article number="13">
     <title>Rarangi 13</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika mo ana haere katoa me ona wahi noho tuturu ai i roto i nga rohe o tona whenua.</para>
+	<para>E whai tika ana ia tangata kia herekore ai te hāereere me te noho ki roto i ngā roherohenga o ia whenua.</para>
       </listitem>
       <listitem>
-	<para>Ko ia tangata e whai-tika kia whakarere i tetahi whenua, ahakoa ko tona whenua ake, a me te hoki ano ki tena whenua tupu.</para>
+	<para>E whai tika ana ia tangata kia puta ki waho o tētahi whenua, ahakoa ko tōna ake, ā, ki te hoki anō ki tōna whenua ake.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -85,10 +84,10 @@
     <title>Rarangi 14</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia rapu kia whiwhi hoki ki tetahi oranga ngakau ki etahi atu whenua ina whanatu ia kia pahemo i nga tukino mona.</para>
+	<para>E whai tika ana ia tangata ki te rapu whakaāhuru ki whenua kē i te pēhitanga i tōna ake whenua, ā, ki te noho pai ki taua whenua kē.</para>
       </listitem>
       <listitem>
-	<para>Ko tenei tika e kore e ahei kia inoitia mo runga i te take whakawhiu i tupu pono ake na etahi hara kahore nei no nga ropu hanga ture, a na roto mai ranei i etahi mahi e peka ke ana i te ahuatanga me nga kaupapa tuturu o te Kotahitanga o nga Mana Nunui o te Ao.</para>
+  <para>Kāhore e taea tēnei tika te whakamahi mehemea e whiua ana te tangata ki tētahi whiu ehara i te kaupapa tōrangapū, ehara rānei i te takahanga o ngā whāinga me ngā mātāpono o Te Kotahitanga o te Ao.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -96,10 +95,10 @@
     <title>Rarangi 15</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai tika ana ki tetahi iwi tuturu mona. Kaua tetahi tangata e meinga kia takirihia atu e te ringa kaha i tona iwi tuturu, a kaua hoki e araia ina mea ia ki tetahi atu iwi hei iwi tuturu mona.</para>
+	<para>E whai tika ana ia tangata ki tētahi karangatanga whenua.</para>
       </listitem>
       <listitem>
-	<para>[Missing?]</para>
+	<para>Kia kaua tētahi tangata e āraitia pokanoatia i tōna karangatanga whenua, e āraitia rānei i te tika ki te whakarerekē i tōna karangatanga whenua.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -107,13 +106,13 @@
     <title>Rarangi 16</title>
     <orderedlist>
       <listitem>
-	<para>Ko nga tane me nga wahine kua eke nei nga tau ki te pakehatanga, e whai-tika ana kia moe tane, wahine hoki, a kia whakatupu uri ki te ao, a kaua e araia tenei tika na runga ï te mea he momo tangata ke atu, he iwi ke, he whakapono ke ranei. E whai mana, ana ratou kia tauriterite te tika i runga i te marena i te wa e noho ana he tane he wahine a tae noatia te wa e wehe tuturu ai.</para>
+	<para>E whai tika ana ngā tāne me ngā wāhine kua eke nei ki te pakeketanga ki te mārena, ki te whakatipu whānau, ā, kāhore nei he herenga ā-iwi, ā-karangatanga whenua, ā- whakapono rānei. He ōrite te whai tika mō te mārena, ki roto i te mārenatanga, i te whakakorenga hoki o te mārena.</para>
       </listitem>
       <listitem>
-	<para>Ko te maramatanga me meinga i urutomotia i runga i te whakaaetanga watea, tuturu hoki a te tane me te wahine e marenatia ana.</para>
+	<para>Me whakaae mārika te tokorua kia mārena rāua i runga i te whakaaro herekore.</para>
       </listitem>
       <listitem>
-	<para>Ko te whanau te hunga tuturu pupuri pono hoki i te kaupapa tika o te iwi, a e tino tika ana kia tiakina e te iwi me te Motu katoa.</para>
+	<para>Ko te whānau te hanga tūturu o te hapori whānui, ā, e whai tika ana kia tiakina e te hapori me te Mana Whenua hoki.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -121,29 +120,29 @@
     <title>Rarangi 17</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia whiwhi ki ona taonga ake, kia whiwhi tahi ranei ratou ko etahi atu.</para>
+	<para>E whai tika ana ia tangata ki te pupuri whenua, taonga hoki, tangata kotahi nei, ā-rōpū anō hoki.</para>
       </listitem>
       <listitem>
-	<para>Kaua tetahi tangata e murua e te ringa kaha i ona taonga ake.</para>
+	<para>Kia kaua e tangohia takekoretia ngā whenua me ngā taonga a te tangata.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="18">
     <title>Rarangi 18</title>
-    <para>1.Ko ia tangata e whai-tika ana ki ona ake whakaaro, o tona hinengaro me tona nei whakapono; e tapiritia ana hoki ki a ia te mana kia watea ia ki te whakauru atu ki tetahi atu whakapono, hahi ranei, a me watea hoki, ki a ia anake ki a ia ranei me etahi atu ki te aroaro o te katoa, ki tetahi wahi wehi ranei, te mana ki te whakarite i tona whakapono, hahi ranei, i runga i te ritenga ako atu i etahi, i whakahaere ranei i ona ritenga, i te karakia me te whakatutuki i ona ahuatanga.</para>
+    <para>E whai tika ana ia tangata kia herekore ai ngā whakaaro, te hinengaro me te whakapono; kei roto i tēnei tika ko te āhei herekore a te tangata kia tahuri i ōna e whakapono ana me te āhei herekore ki te whai me te whakatinana i ngā whakapono nei mā te whakaako, mā te mahi, mā te karakia i tōna kotahi, i roto rānei i te rōpū, ki te wāhi tūmataiti, ki te wāhi tūmatanui rānei.</para>
   </article>
   <article number="19">
     <title>Rarangi 19</title>
-    <para>Ko ia tangata e whai-tika ana ki tona whakaaro i kite ai, a ki te whakapuaki hoki i ona whakaaro; ko tenei tika e tapiritia mai ana te ahei ona ki te pupuri i tana i whakaaro ai, a kaua hoki a ia e whakararurarutia a ka ahei hoki a ia ki te rapu, ki te tango mai me te tuku atu i nga whakamarama me nga rapunga whakaaro o te hinengaro, ahakoa pewhea te huarahi, i nawhea atu ranei i runga i nga rohe whakatakoto a te tangata.</para>
+    <para>E whai tika ana ia tangata kia herekore ai ōna whakaaro me āna putanga korero, kei roto i tēnei tika ko te herekoretanga a te tangata ki te pupuri i ōna whakaaro me te kore raweke mai a tētahi atu, ko te herekoretanga hoki ki te rapu, ki te whiwhi, ki te tuku pārongo, whakaaro hoki mā ngā momo pāhotanga, ā, ahakoa ngā roherohenga.</para>
   </article>
   <article number="20">
     <title>Rarangi 20</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia watea ia ki te whakatu hui, ropu ranei, i runga i te ritenga pupuri i te maungarongo.</para>
+	<para>E whai tika ana ia tangata kia herekore ai āna huihuinga me ōna hononga.</para>
       </listitem>
       <listitem>
-	<para>Kaua tetahi tangata e akina kia uru noa ki tetahi ropu.</para>
+	<para>Kia kaua tētahi e ākina kia uru ki tētahi rōpū.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -151,49 +150,49 @@
     <title>Rarangi 21</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia te tangata e whai-tika ana kia whai wahi ki nga whakahaere kawanatanga o tona whenua, a ia tonu a ma roto ata ranei i nga mangai i ata waitohutia.</para>
+	<para>E whai tika ana ia tangata kia whai wāhi ki ngā whakahaere kāwanatanga o tōna whenua, hāngai tonu atu, mā te whai wāhi rānei ki ngā māngai kua oti nei te whakatū herekore nei.</para>
       </listitem>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia tauriterite te huarahi atu mo te uru ki nga mahi mo te katoa i tona nei whenua.</para>
+	<para>E whai tika ana ia tangata kia ōrite te whai wāhi ki ngā ratonga kāwanatanga o tōna whenua.</para>
       </listitem>
       <listitem>
-	<para>Ko ta te iwi i whakatau ai me meinga hei kaupapa mo te mana o te kawanatanga; ko tenei whakatau me meinga kia whakapuakina ia wa ia wa i runga i te pooti tika he mea atu tuku ki te katoa i runga i te mana pooti tauriterite o tetahi tangata, a me meinga hoki na te pooti puku a na tetahi tikanga ranei i rite atu ki tera te watea o te tangata ki te pooti ki tana i whakaaro ai.</para>
+	<para>Ko tā te iwi i whakatau ai koina te pūtake o te mana o te kāwanantanga, kia mōhiotia ai te mana o te iwi, ka whakatūria he pooti i ētahi wā i runga i te kaupapa whakaōrite mana pooti ki te katoa, ā, me pooti huna, me whakahaere rānei he kaupapa pooti e rite nei te herekoretanga.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="22">
     <title>Rarangi 22</title>
-    <para>Ko ia tangata, i te mea no roto ia i te iwi, e whakatika ana kia whiwhi ki nga tikanga toko i te ora mo te iwi, a e tika ana kia whakaritea atu ki a ia, i na roto atu i nga whakahaere whanui a tona iwi, i na roto mai ranei i nga whakakotahitanga o nga mahi a nga iwi o te ao a kia rite hoki ki te kaha o nga whakahaere a-ropu o roto ia iwi ia iwi te oranga tinana te noho i roto i te iwi., me nga tika ki nga whakahaere hapai i te mauri o te tangata, e tika nei kaua e hapa te tangata i enei mea hei pupuri i tona ihi me te whakawatea hoki i te tupu pakari o te tu-rangatira o te tangata.</para>
+    <para>E whai tika ana ia tangata, ki roto i ō rātau hapori, kia whakawhiwhia ki te āwhina ā-hapori, ā, me āhei te tangata ki te whakatinana i ōna tika ohanga, hapori, ahurea hoki e hāngai pū ana ki tōna mana me te whakatipuranga herekore o tōna rangatiratanga, mā runga i ngā mahi o tōna whenua me ngā mahi ngātahi o ngā whenua o te ao, ki runga anō i te āhua me ngā rawa o tōna whenua.</para>
   </article>
   <article number="23">
     <title>Rarangi 23</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia whiwhi ki te mahi, kia watea hoki ki te whawha ki tana mahi i hiahia ai, kia tika kia pai hoki nga ahuatanga o tana mahi a kia tiakina hoki kei noho kare mahi ia.</para>
+	<para>E whai tika ana ia tangata ki te whai mahi, ki te whai herekore i te momo mahi e pīrangitia ana, kia tika, kia pai hoki ngā āhuatanga o te mahi, ā, kia tiakina i te kore mahi.</para>
       </listitem>
       <listitem>
-	<para>Ko ia tangata, ahakoa pewhea, e tika ana kia whiwhi ki te utu taurite mo nga mahi i tauriterite nga ahuatanga.</para>
+	<para>E whai tika ana ia tangata, me te kore whakatoihara, kia utua ki te utu taurite mō te mahi taurite.</para>
       </listitem>
       <listitem>
-	<para>Ko ia tangata e mahi ana e whai-tika ana kia utua ki te utu tika pai hoki, kia ahei ai te whiwhi ona me tana whanau ki te oranga e tika nei hei whakaara i te ua o te tangata i te ao nei; a me tapiri atu ki enei, ina kitea e tika ana kia pera, etahi atu awhina o roto i nga whakahaere toko i te ora mo te iwi.</para>
+	<para>E whai tika ana ia tangata e mahi ana kia utua rātau ki tētahi utu e tika ana, e pai ana e tū tangata ai rātau me ō rātau whānau, ā, me tāpiri atu he momo āwhina ā-hapori memehea e hiahiatia ana.</para>
       </listitem>
       <listitem>
-	<para>Ko ia tangata e ahei ana ki te waihanga ki te whakauru ranei ki tetahi ropu kaimahi hei tiaki i nga ahuatanga katoa e pa ana ki nga huarahi mahi mona.</para>
+	<para>E whai tika ana ia tangata ki te whakatū, ki te whakauru atu rānei ki tētahi rōpū kaimahi, e tiakina ai ō rātau take.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="24">
     <title>Rarangi 24</title>
-    <para>Ko ia tangata e whai-tika ana kia okioki, noho noaiho ranei i ona wa ano; ka tapiritia ki tenei, me meinga ko ona haora mahi me whakawhaiti ano ki nga haora e tika ana, me whiwhi hoki ia wa ia wa ki nga ra kore mahi i runga i te ritenga haere tonu o te utu mona i ana ra.</para>
+    <para>E whai tika ana ia tangata ki te whakatā, ki te whakangahau hoki, me whakarite ngā hāora mahi kia pēnei, me whakawhiwhi hoki he wā hararei e utua ana.</para>
   </article>
   <article number="25">
     <title>Rarangi 25</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia whiwhi ki te oranga e hangai ana ki te oranga totika mo tona tinana me ona ahuatanga katoa, ona ake me tana whanau; i te kai. i tekakahu, i te whare, i te rongoa me nga whakaora i nga mauiui o te tinana, a tae atu ki nga huarahi toko i te ora mo te iwi e tika ana, a me whiwhi hoki ai i te tika, me te manaakitanga tuturu mona ina tupono mai nga wa kore mahi, nga mauiui o te tinana, nga wharanga, te pouarutanga, te kaumatuatanga, a te kore ranei e whiwhi i te oranga mona i nga runga mai i etahi ahuatanga kaore nei e taea e ia te pewhea ake.</para>
+	<para>E whai tika ana ia tangata ki tētahi taumata oranga e rite ana mō te hauora o te tangata me tōna whanau, arā kia whai kai, kia whai kākahu, kia whai whare, kia whai rongoā, kia whai ratonga hapori hoki, me te tika hoki kia haumarutia inā ka pāngia e te kore mahi, e te māuiui, e te hauā, e te pouwarutanga, e te kaumātuatanga,ete korengarāneiewhaiorangamāhuarahikēekoreetaeate pēhea.</para>
       </listitem>
       <listitem>
-	<para>Ko nga wahine whanau me te hunga tamariki e tika ana kia ata whakaarohia kia manaakitia hoki. Ko te katoa o nga tamariki, ahakoa i whanau mai i te hunga i te marenatia kahore ranei i marenatia, me meinga kia rite tahi te whiwhi ki nga awhina o nga ritenga toko i te ora mo te iwi.</para>
+	<para>E whai tika ana ki te āta manaaki te ūkaipōtanga me te tamarikitanga. Ko ngā tamariki katoa, ahakoa i whānau mai ki roto i te mārena, kahore rānei , ka tiaki ngātahi.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -201,13 +200,13 @@
     <title>Rarangi 26</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e tika ana kia watea ki a ia nga huarahi o te matauranga. Ko nga huarahi o nga akoranga me noho kore utu, otira i nga timatanga atu me ona kaupapa tuturu. Ko nga timatanga atu o nga huarahi akoranga me meinga kia utaina ki te katoa, kaua ma te hiahia noa o te tangata. Ko nga akoranga mo nga mahi-a-ringa me nga mahi-a-hinengaro me meinga kia whanui te horo ki te katoa, a ko nga akoranga ki nga taumata ikeike o te matauranga me rite tahi te watea ki te katoa i na runga ano ra i te kitea o te totika o te tangata.</para>
+	<para>E whai tika ana ia tangata ki te mātauranga. Me kore utu te mātauranga, ki roto i ngā kura tuatahi me ngā pūtaketanga o te ako. Me uru te katoa o ngā tamariki ki te kura tuatahi. Me whānui te whakarato i te mātauranga hangarau me te mātauranga ngaio, ā, me āhei ngā whare wānanga ki ngā tāngata katoa ki runga i te āhua o ō rātau pūkenga.</para>
       </listitem>
       <listitem>
-	<para>Ko nga huarahi o te akoranga me whakaanga atu ki nga wahi e puta topu mai ai nga hua totika o te tangata, kia meinga ai hoki hei kaupapa whakapakari i nga mana o te tangata me nga tino kaupapa o te rangatiratanga o tona oranga i tenei ao. Me meinga i tenei ritenga kia ata matatau tetahi ki tetahi, kia watea i te ngakau wene, kia noho hoki i runga i te whakahoahoa tetahi iwi ki tetahi iwi, tetahi momo tangata me tetahi momo tangata me tetahi ropu whakapono ki tetahi atu ropu whakapono, a me meinga hoki kia hapai i nga whakahaere a te Kotahitanga o nga iwi Nunui o te Ao he mea a mau ai te maungarongo ki te mata o te whenua.</para>
+	<para>Ko te aronga matua o ngā mahi mātauranga, he whakatipu i te wairua o te tangata, ko te whakapiki i te whakaaro nui o te tangata ki ngā tika tangata me ngā herekoretanga taketake. Mā ngā mahi mātauranga nei, me whakatairanga ko te māramatanga o tētahi ki tētahi, ko te aroha, ko te whakahoatanga ki waenga i ngā whenua, i ngā iwi, i ngā whakapono, me tautoko hoki i ngā mahi a Te Kotahitanga o te Ao e mau ai te rongo.</para>
       </listitem>
       <listitem>
-	<para>Kei nga matua te mana tuatahi ki te tohu i te ahua o nga akoranga hei tuku ki a ratou tamariki.</para>
+	<para>E whai tika ana ngā mātua ki te whiriwhiri i te momo mātauranga me whakawhiwhi ki ā rātau tamariki.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -215,33 +214,33 @@
     <title>Rarangi 27</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia watea tona huarahi mo te whakauru atu ki nga whakahaere hapai i te hinengaro tangata i roto i te iwi, kia whiwhi hoki ki nga oranga ngakau o roto i nga mahi ataahua, a kia pa tahi atu ki nga whakahaere hohonu o te matauranga e ahu whakamua atu ana, me ona hua katoa.</para>
+	<para>E whai tika ana ia tangata kia whai wāhi herekore nei ki te ao ahurea o te hapori, kia whai ngahau i ngā mahi toi, kia whai wāhi hoki ki ngā mahi pūtaiao me āna hua.</para>
       </listitem>
       <listitem>
-	<para>Ko ia tangata e whai-tika ana kia ata tiakina kia puta ano ki a ia nga hua o nga mea oranga ngakau, oranga tinana ranei, i na roto mai nei i nga mahi o te hohohutanga o te matauranga, i nga pukapuka whai hua i tuhia, i nga mahi ataahua ranei nana ake nai i whakapuawai ki te ao.</para>
+	<para>E whai tika ana ia tangata kia tiakina ngā take ā-hinengaro, ā-tinana e hua ake ana i ngā mahi pūtaiao, tuhituhi, mahi toi e mahia ana e te tangata.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="28">
     <title>Rarangi 28</title>
-    <para>Ko ia tangata e whai-tika ana ki nga ritenga o te noho pai o te iwi me te ao katoa, ma reira nei e tino tuturu ai nga tika me nga rangatiratanga kua whakararangitia nei ki roto i tenei Whakapuakitanga.</para>
+    <para>E whai tika ana ia tangata ki tētahi punaha hapori i tōna whenua me te ao whānui e mana katoa ai ngā tika me ngā herekoretanga kei tēnei Whakapuakitanga e rārangi ana.</para>
   </article>
   <article number="29">
     <title>Rarangi 29</title>
     <orderedlist>
       <listitem>
-	<para>Ko ia tangata me mahi i ana mahi mo te iwi, ma reira anake nei e watea ai, e tutuki tuturu ai hoki te waihangatanga o tona hinengaro.</para>
+	<para>E whai kawenga ana ia tangata ki roto i te hapori kei konā ka taea te whakatipuranga herekore o te wairua o te tangata ki ōna taumata e hiahiatia ana.</para>
       </listitem>
       <listitem>
-	<para>I te wa i whakarite ana ia i ona tika me ona rangatiratanga, ko ia tangata me meinga ko nga ara anake mona me ma roto i nga whakatau a te ture, me motuhake hoki aua arai hei mea a mau ai e mohiotia ai e whakanuia ai hoki nga tika me nga rangatiratanga e etahi atu tangata, a hei mea hoki e tutuki ai nga ritenga pono o te noho kore-hara, o te noho i te rangimarie o te katoa me te painga whanui ki nga iwi e noho ana i raro i te mana kawanatanga o te katoa o nga iwi o tetahi whenua.</para>
+	<para>I te tangata e whai ana i ōna tika me ōna herekoretanga, ka herea ia ki ngā tikanga anake o te ture e mau ai, e mana ai ngā tika me ngā herekoretanga o tāngata kē, e tutuki ai ngā āhuatanga o te matatika, o te nahanaha o te hapori, o te painga whānui o te hapori manapori.</para>
       </listitem>
       <listitem>
-	<para>Ko enei tika me enei rangatiratanga kaua rawa e meinga kia whakahaerea i runga i etahi tikanga me etahi atu kaupapa e peka ke ana i a te Kotahitanga o nga Iwi Nunui o te Ao i mea ai.</para>
+	<para>Kia kaua rawa e whāia ēnei tika me ēnei herekoretanga mehemea ka takahia nei ngā mātāpono o Te Kotahitanga o Te Ao.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="30">
     <title>Rarangi 30</title>
-    <para>Kahore rawa i roto i tenei Whakapuakitanga tetahi mea e ahei ana kia whakamoaritia tera kei tetahi Mana Kawanatanga, kei tetahi ropu, kei tetahi tangata ranei tetahi mana ki te whakahaere i tetahi ritenga, ki te mahi ranei i tetahi mahi e anga atu ana hei tikanga turaki i tetahi o nga mano me nga rangatiratanga e mau ake nei.</para>
+    <para>Kāhore he kōrero i tēnei Whakapuakitanga ka taea te kī māna e whai tika ai te Mana Whenua, te rōpū, te tangata rānei ki te mahi i tētahi mahi e korehāhātia ai ngā tika me ngā herekoretanga e rārangi ake nei.</para>
   </article>
 </udhr>


### PR DESCRIPTION
As @moyogo explains [here](https://github.com/googlefonts/lang/issues/55#issuecomment-2345527050):

> The OHCHR.org’s [PDF](https://www.ohchr.org/sites/default/files/UDHR/Documents/UDHR_Translations/mbf.pdf) of the Maori UDHR has the macrons while the [webpage](https://www.ohchr.org/en/human-rights/universal-declaration/translations/maori) does not. Both have a different Maori translation. My guess is the webpage has an old translation, without macron either because it predates the adoption of the macron in the 1987 spelling or because macrons were lost in digitization.
> Either way, the version with macron should be used.

This is a transcription of the PDF version.