### PR TITLE
udhr_hva (hus): replace éyaltai{ab by éyaltaláb

### DIFF
--- a/data/udhr/udhr_hva.xml
+++ b/data/udhr/udhr_hva.xml
@@ -156,7 +156,7 @@
             <para>Patal an k'wajíl in kwa'al tin uchbíl ti t'aja' ti éyal ani kin bijiy jita' in kulbétnál ti éyal tin kwenchál.</para>
          </listitem>
          <listitem>
-            <para>Patal in kwa'ai tin uchbíl ka tolmiyat abal kin bajuw ka ulits al an pulik éyaltai{ab tin kwenchál.</para>
+            <para>Patal in kwa'ai tin uchbíl ka tolmiyat abal kin bajuw ka ulits al an pulik éyaltaláb tin kwenchál.</para>
          </listitem>
          <listitem>
             <para>Tin káwintal an bichow taja'its ti k'wajat in tujtal an éyaltaláb. An bichow in tomnál kin bijiy in éyalil ani an éyal kwa'al kin t'aja' jawa'kin uluw an bichow.</para>


### PR DESCRIPTION
The spelling éyaltaláb is used twice in other sentences.

The morphology seems to be éyal-ta-láb (authority-ABSTR-GEN).

It’s not clear if the difference between éyaltaláb and eyaltaláb, both seen in other  Huasteco documents, is an issue here. But since éyaltai{ab starts with é it’s probably éyaltaláb not eyaltaláb.