### PR TITLE
udhr_gle: replace 00B4 ´ by 0027 '

### DIFF
--- a/data/udhr/udhr_gle.xml
+++ b/data/udhr/udhr_gle.xml
@@ -140,7 +140,7 @@
             <para>Tá ag gach uile dhuine an ceart go mbeidh saoirse aige teacht ar tionól agus gabháil le comhlachas go sítheoilte</para>
          </listitem>
          <listitem>
-            <para>Ní cead a chun d´fhiacha ar dhuine ar bith gabháil le haon chomhlachas áirithe.</para>
+            <para>Ní cead a chun d'fhiacha ar dhuine ar bith gabháil le haon chomhlachas áirithe.</para>
          </listitem>
       </orderedlist>
    </article>


### PR DESCRIPTION
00B4 ´ is used a single time for the shortened "do", 0027 ' is used in occurences in the translation.