### PR TITLE
udhr_kwi: replace + by ɨ

### DIFF
--- a/data/udhr/udhr_kwi.xml
+++ b/data/udhr/udhr_kwi.xml
@@ -12,20 +12,20 @@ humanukaz karakas wantuzpa</para>
       <para>Ataptakitpa suazne prockamatai an wantuskasa kuintakitpa sara an samtleara
 jeneralkas kuintakit</para>
       <para>Anpayu maza chalkuil tisiemprewa maza pikam ampara tuil la Asamtleane
-jeneralne an nasiuneskaz unitakaz aprupakitpa pruckamakir+t an teckarasiunkaz
-sar+t uniperzalkaz nitchan humanukaz sunkaz textura wan sar+t fikurakas sara
+jeneralne an nasiuneskaz unitakaz aprupakitpa pruckamakirɨt an teckarasiunkaz
+sarɨt uniperzalkaz nitchan humanukaz sunkaz textura wan sarɨt fikurakas sara
 pakinakaz mamazkaz ankaz historikukaz Asamtleara paikuat wantuzpa paiskaz
 miemprukaz sune puplikara an textura teckarasiunkit tispusierakit mamaz pusta
-tistripuikir+texpuestukit p+nk+tta izkit kuintakit p+nk+h kammu yalta mamaz
+tistripuikirɨtexpuestukit pɨnkɨtta izkit kuintakit pɨnkɨh kammu yalta mamaz
 estaplecimienturaz sun kamtarawai tuamtus kuntisiunkas pulitikaz an
 territuriukaz</para>
    </note>
    <preamble>
       <title>Preámbulo</title>
-      <para>Kunsiderakitpa chima lipertachan la justisiakaz y la pazkaz muntuz m+jan sun
-rekunusimientukaz an tiknitadkaz inteinsekakaz an nit +n kawuarus
+      <para>Kunsiderakitpa chima lipertachan la justisiakaz y la pazkaz muntuz mɨjan sun
+rekunusimientukaz an tiknitadkaz inteinsekakaz an nit ɨn kawuarus
 inalienaplekaz wantuzpa miemprokaz kualkaz humanakaz</para>
-      <para>Kunsiterakitpamakpaz an teskunucimientoksz menuspreciukaz sun nit +m+zna
+      <para>Kunsiterakitpamakpaz an teskunucimientoksz menuspreciukaz sun nit ɨmɨzna
 humanukaz an urijinakitpa acturuzkas ultrajantikaz sunkaz la kunsienciakaz
 humanitakaz que se han pruckamakitpa misha aspiraciukaz mamaz elepakitpa
 ampukaz apperimientune anña muntune suntuzne serekaz humanukaz
@@ -37,99 +37,99 @@ supremukaz recursukaz repelionkaz kuntramakpaz tiraniakaz upresiunkaz</para>
       <para>Kunciderakitpamakpaz mamaz esencialkaz prumuperkitpa an tesarruyakitpa
 relasiunkaz amistusurakaz uspëlruzpa nasiunkaz,</para>
       <para>Kunciderakitpa an puepluskaz nasiuneskaz unitaskaz ankaz reafirmakitpa an kartara
-sun nitchanpamakpas wantuskasa fe m+jatpa an nitm+jatpa ampukaz ashampakaz
+sun nitchanpamakpas wantuskasa fe mɨjatpa an nitmɨjatpa ampukaz ashampakaz
 kaiztamai teckaratukitmai resueltukitmai susialkaz pruperkitpa prukreso elepakitpa
 an nipelkaz tuamkaz ayukta maza kunceptukitpa akal lipertadkaz</para>
       <para>Kunciterakitpa sun estatukaz miempruruzkaz an komprometikitpa asekurakitpa
 kuperasiunkaz sun la urkanizacionkaza naciponeskaz unidaskaz respetikitpa
 efectipukaz univer5alkaz derechokaz libertakaz fundarventaleska ampukaz,</para>
-      <para>Kusiderakitpamakpaz kuncepciónkitpa kumunkaz an nitchatpamai m+nkas
+      <para>Kusiderakitpamakpaz kuncepciónkitpa kumunkaz an nitchatpamai mɨnkas
 kachapmuchimaimasain chatpa</para>
    </preamble>
    <article number="2">
       <title>Artikulu paz</title>
-      <para>Maza wantuz awa m+jan wuantuz nitchatpa karakas m+nkaskachapmuchi
+      <para>Maza wantuz awa mɨjan wuantuz nitchatpa karakas mɨnkaskachapmuchi
 Mamaz kualtuz puchakas awapit relionkaz upini6nkaz politikakaz mamaztusne
 indulekaz nacionalkaz socialkaz posicionkaz pialkaz chikta mamaztuskaz
 kunticionkaz</para>
        <para>paz. Suntakaz sarawai tisticionkaz chiwuasha kunticionkaz jurftika
-internacionalkaz paiskaz territuiukas mamaz kupairuwai p+na kaiztawuai
-intepetientene purai atministracionne autunumukaz napt+t chiwuashai
+internacionalkaz paiskaz territuiukas mamaz kupairuwai pɨna kaiztawuai
+intepetientene purai atministracionne autunumukaz naptɨt chiwuashai
 limitaciónkaz superaniakaz</para>
   </article>
    <article number="3">
       <title>Artikulu kutña</title>
-      <para>Wuantaruz intipituokaz m+jatpa nitmtjatpai tuammakpaz liberta purai
-sekuritakaz m+jatpamakpaz awaruzpa</para>
+      <para>Wuantaruz intipituokaz mɨjatpa nitmtjatpai tuammakpaz liberta purai
+sekuritakaz mɨjatpamakpaz awaruzpa</para>
    </article>
    <article number="4">
       <title>Artikulu ampara</title>
-      <para>m+nkaz puran napt+t esckapitukaz serpitumprekaz</para>
+      <para>mɨnkaz puran naptɨt esckapitukaz serpitumprekaz</para>
    </article>
    <article number="5">
       <title>Artikulu shish</title>
-      <para>Wantaruspa Kara napt+t turturane m+nkas chi wantm+jan inhumanurus</para>
+      <para>Wantaruspa Kara naptɨt turturane mɨnkas chi wantmɨjan inhumanurus</para>
    </article>
    <article number="6">
       <title>Artikulu wat</title>
-      <para>Wantuz uspa humanukaz m+jmai nitm+jan wantuspa kai rekunucimiento up
+      <para>Wantuz uspa humanukaz mɨjmai nitmɨjan wantuspa kai rekunucimiento up
 persona litai juritika</para>
    </article>
    <article number="7">
       <title>Artikulu ita</title>
-      <para>Wanturus kawarain mai annamin ley m+jmai sunka nitm+jan m+jan kawarain
-prutekitpa ley m+jan wantuspa m+jmai nit +n kawuara m+jan pruteccionm+jan
-kuntram+jan paitarusa</para>
+      <para>Wanturus kawarain mai annamin ley mɨjmai sunka nitmɨjan mɨjan kawarain
+prutekitpa ley mɨjan wantuspa mɨjmai nit ɨn kawuara mɨjan pruteccionmɨjan
+kuntramɨjan paitarusa</para>
    </article>
    <article number="8">
       <title>Artikulu tuil</title>
-      <para>Wantuspa awa m+jan nit +tpa m+jmakpaz an recursukaz efectipu an na m+jatpa
-tripunalkaz nacionalkaz rumpet+ntekaz suna ampara kitpa kuntramakpaz an
-aktuskza piolakiman an nit +tpamakpas funtamentaleskaz piankar+t an
+      <para>Wantuspa awa mɨjan nit ɨtpa mɨjmakpaz an recursukaz efectipu an na mɨjatpa
+tripunalkaz nacionalkaz rumpetɨntekaz suna ampara kitpa kuntramakpaz an
+aktuskza piolakiman an nit ɨtpamakpas funtamentaleskaz piankarɨt an
 kunstitucionne an leykaz ishtawamakpas.</para>
    </article>
    <article number="9">
       <title>Artikulu pikam</title>
-      <para>m+nkaz p+r+chi arpitrariamentene m+nakazpizmuchi wuasana pisht+t.</para>
+      <para>mɨnkaz pɨrɨchi arpitrariamentene mɨnakazpizmuchi wuasana pishtɨt.</para>
    </article>
    <article number="10">
       <title>Artikulu maza chalkuil</title>
-      <para>Wantarusa awane m+jmai nit +m+zna m+ji an kunticioneskaz kawarain
+      <para>Wantarusa awane mɨjmai nit ɨmɨzna mɨji an kunticioneskaz kawarain
 m-t-Jatpai kashaptawai wantarusa kashtawai sun justiciane sunta tripunalta
-intipentientera imparcialkaz kara terminaciunkaz kitpa sun nit +tpai uplikaciun
-m+ji an examenta chiwasha kÇlshaptawai kontramakpaz uzparusa.</para>
+intipentientera imparcialkaz kara terminaciunkaz kitpa sun nit ɨtpai uplikaciun
+mɨji an examenta chiwasha kÇlshaptawai kontramakpaz uzparusa.</para>
    </article>
    <article number="11">
       <title>Artikulu maza maza</title>
       <orderedlist>
          <listitem>
-            <para>Wanturuzpa awakaz akLJsakitpa ,ah telitukaz m+jatpa nit +npa wantarusa
-kaishkuintakitpa an leyne juiciukitpa pupliku wat samat m+jatpai karntiakaz wan
-samatm+jatpai tefensakaz sarawai chiwashakaz.</para>
+            <para>Wanturuzpa awakaz akLJsakitpa ,ah telitukaz mɨjatpa nit ɨnpa wantarusa
+kaishkuintakitpa an leyne juiciukitpa pupliku wat samat mɨjatpai karntiakaz wan
+samatmɨjatpai tefensakaz sarawai chiwashakaz.</para>
          </listitem>
          <listitem>
-            <para>Paz .m+nkaz kuntenakitpa sun kumisiunkaz nit +n naciunalkaz internaciunalkaz
-chiwashakaz p+na t+ntakal kumicionkaz kuailkir+t tawa septawai kara ishtawai
+            <para>Paz .mɨnkaz kuntenakitpa sun kumisiunkaz nit ɨn naciunalkaz internaciunalkaz
+chiwashakaz pɨna tɨntakal kumicionkaz kuailkirɨt tawa septawai kara ishtawai
 paitaruza kuintakitpa wantuskasa.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
       <title>Artikulukaz maza paz</title>
-      <para>M+nkaz kara ubjetipukaz injerenciane arpitrariakaz an pitakaz pripatakaz an
+      <para>Mɨnkaz kara ubjetipukaz injerenciane arpitrariakaz an pitakaz pripatakaz an
 kualkaz up tumicilione sun konrrespontientene atakekaz up hunrane up
-reputacionkaz .wantuzpa awaruspa m+jmai dereçhom+ji proteccionne leyta
-kontra m+jmai injerenciakaz wualmaltamai</para>
+reputacionkaz .wantuzpa awaruspa mɨjmai dereçhomɨji proteccionne leyta
+kontra mɨjmai injerenciakaz wualmaltamai</para>
    </article>
    <article number="13">
       <title>Artikulumaza kutña</title>
       <orderedlist>
          <listitem>
-            <para>Wantus awarusne m+jmai nit +n sirkularkaz lipremente mai elijelitpa
+            <para>Wantus awarusne mɨjmai nit ɨn sirkularkaz lipremente mai elijelitpa
 resistensiakas an su territuriumai sun estaduras</para>
          </listitem>
          <listitem>
-            <para>Paz. Wantuspa awaruspakai m+jmai watmilna nitm+lna chiwacha sun
+            <para>Paz. Wantuspa awaruspakai mɨjmai watmilna nitmɨlna chiwacha sun
 pamikawa an kailninna sun paista,</para>
          </listitem>
       </orderedlist>
@@ -138,7 +138,7 @@ pamikawa an kailninna sun paista,</para>
       <title>Artikulu maza ampara</title>
       <orderedlist>
          <listitem>
-            <para>Maza kainam wan awaruza t+nta sunkanan saim watpuran m+ntat wan sura</para>
+            <para>Maza kainam wan awaruza tɨnta sunkanan saim watpuran mɨntat wan sura</para>
          </listitem>
          <listitem>
             <para>Paz, An nitnezazachi</para>
@@ -149,12 +149,12 @@ pamikawa an kailninna sun paista,</para>
       <title>Articulu maza shish</title>
       <orderedlist>
          <listitem>
-            <para>Maza. Wantuz awaruz m+jmai nitm+jmatpaz maza p+puchin</para>
+            <para>Maza. Wantuz awaruz mɨjmai nitmɨjmatpaz maza pɨpuchin</para>
          </listitem>
          <listitem>
-            <para>Paz. m+nkas waitkischazachi ut p+p+rurane chinkas maizmizhizh kizchasaçi
-sunkana nitm+ne ut suranePaz. m+nkas waitkischazachi ut p+p+rurane chinkas maizmizhizh kizchasaçi
-sunkana nitm+ne ut surane</para>
+            <para>Paz. mɨnkas waitkischazachi ut pɨpɨrurane chinkas maizmizhizh kizchasaçi
+sunkana nitmɨne ut suranePaz. mɨnkas waitkischazachi ut pɨpɨrurane chinkas maizmizhizh kizchasaçi
+sunkana nitmɨne ut surane</para>
          </listitem>
       </orderedlist>
    </article>
@@ -162,18 +162,18 @@ sunkana nitm+ne ut surane</para>
       <title>Articulu maza wak</title>
       <orderedlist>
          <listitem>
-            <para>Maza ampuruzne ashampakaz mucitupar+ne sunkanan nit m+J kawarain izht+t
-kual mam+z p+pHuraz kualne mam+z izt+t, karane sunkanan m+tmu
-achanparane kualtusane chatpamai kawara nit m+jatpamai mishuran
-kasalakitpa annamin kasalakitpa kara watm+ltawai an kasalakitpa.</para>
+            <para>Maza ampuruzne ashampakaz mucituparɨne sunkanan nit mɨJ kawarain izhtɨt
+kual mamɨz pɨpHuraz kualne mamɨz iztɨt, karane sunkanan mɨtmu
+achanparane kualtusane chatpamai kawara nit mɨjatpamai mishuran
+kasalakitpa annamin kasalakitpa kara watmɨltawai an kasalakitpa.</para>
          </listitem>
          <listitem>
-            <para>Paz. Masain annamin masainchan m+nkasakazshi kashkuintakitpa mamaztusa
-wat minna ashampakaz nit +n wat m+lna kalakin.</para>
+            <para>Paz. Masain annamin masainchan mɨnkasakazshi kashkuintakitpa mamaztusa
+wat minna ashampakaz nit ɨn wat mɨlna kalakin.</para>
          </listitem>
          <listitem>
-            <para>Maza au kualtuz anna pit, puramtus fundamentalne susietakaz m+jmai nit+n
-m+jan prutejikitpamakpas au sucietakaz an paistane.</para>
+            <para>Maza au kualtuz anna pit, puramtus fundamentalne susietakaz mɨjmai nitɨn
+mɨjan prutejikitpamakpas au sucietakaz an paistane.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -181,10 +181,10 @@ m+jan prutejikitpamakpas au sucietakaz an paistane.</para>
       <title>Artikulu maza ita</title>
       <orderedlist>
          <listitem>
-            <para>Mata pwantus awarusne m+jmai nit+n+npa auruspa kai pakashpâ kulectipamai</para>
+            <para>Mata pwantus awarusne mɨjmai nitɨnɨnpa auruspa kai pakashpâ kulectipamai</para>
          </listitem>
          <listitem>
-            <para>Maza m+nkas wuacha auruspamai an nit m+jan aruspa au pamikamakpas
+            <para>Maza mɨnkas wuacha auruspamai an nit mɨjan aruspa au pamikamakpas
 minkas nakamchi au kaltus katmishna suain purammakpas.</para>
          </listitem>
       </orderedlist>
@@ -192,29 +192,29 @@ minkas nakamchi au kaltus katmishna suain purammakpas.</para>
    <article number="18">
       <title>Artikulu maza tuil</title>
       <para>Au tuampakpaz masainpa purammakpaz kolectipamentekaz pupliku puram nit
-m+jmakpaz nit +tpamakpaz an kamtamtus kara wuat +n+n an kalne.</para>
+mɨjmakpaz nit ɨtpamakpaz an kamtamtus kara wuat ɨnɨn an kalne.</para>
    </article>
    <article number="19">
       <title>Artikulu maza pikam</title>
-      <para>Wantuz paittarus nit+n+n p+na wat nit chatpamakpas upiuonkas m+jatpai wat
-nit +n kachapnachiwal m+nakas m+marawai chiwacha infurmaciunkaz kitpa
-frunteraras chiwacha m+mana.</para>
+      <para>Wantuz paittarus nitɨnɨn pɨna wat nit chatpamakpas upiuonkas mɨjatpai wat
+nit ɨn kachapnachiwal mɨnakas mɨmarawai chiwacha infurmaciunkaz kitpa
+frunteraras chiwacha mɨmana.</para>
    </article>
    <article number="20">
       <title>Artikulu Paz chalkuil</title>
       <orderedlist>
          <listitem>
-            <para>Maza. Wantuspa awaruspa nit +npa lipertakaz wanmaktawai asociacionkas
+            <para>Maza. Wantuspa awaruspa nit ɨnpa lipertakaz wanmaktawai asociacionkas
 pasiflkakaz.</para>
          </listitem>
          <listitem>
-            <para>Paz .m+nkaspuerichi karakas nit +tpa +nintawai asuciacionta.</para>
+            <para>Paz .mɨnkaspuerichi karakas nit ɨtpa ɨnintawai asuciacionta.</para>
          </listitem>
           <listitem>
-            <para>Kutna. p+p+lukasa wat +tpamai kaksaruska5a t+ntaruskasa puplikukas
-kaiwintayva paitarùsa kuintakianashi maintasne aza +n munnaautentikas sanais
+            <para>Kutna. pɨpɨlukasa wat ɨtpamai kaksaruska5a tɨntaruskasa puplikukas
+kaiwintayva paitarùsa kuintakianashi maintasne aza ɨn munnaautentikas sanais
 wanmaktawai azachatpa wantuskasa kawarain puinain kiantawai pailtarus
-m+latpa kiantawai wantuspakai.</para>
+mɨlatpa kiantawai wantuspakai.</para>
          </listitem>
      </orderedlist>
    </article>
@@ -222,7 +222,7 @@ m+latpa kiantawai wantuspakai.</para>
       <title>Artikulu paz maza</title>
       <orderedlist>
          <listitem>
-            <para>Wantuspa awaruspa nit +tpai wuuanmaktawuai kaksamiwuakasa AP paistas
+            <para>Wantuspa awaruspa nit ɨtpai wuuanmaktawuai kaksamiwuakasa AP paistas
 uskasa kuintakin aptas kakuras kasa wanmakmuruskasa masamasain
 sairawamakpas.</para>
          </listitem>
@@ -236,54 +236,54 @@ sairawamakpas.</para>
    </article>
    <article number="22">
       <title>Artikulu Paz Paz</title>
-      <para>Wantus awaruskasa nit m+jan an kalne uspain saanapa sun kal konticionkas wat
-kalkitpa ekitatipa ishmukas m+jatpa karakas esfuesu m+jatpa wat wanmaktawa
-izan pialkas t+ntaruskasa paranitpai pais kas nit +n pialkasa auruspa tGamtuspa
-m+nkas kasaptachiwa punfan tuan anna +n paittaruskasa.</para>
+      <para>Wantus awaruskasa nit mɨjan an kalne uspain saanapa sun kal konticionkas wat
+kalkitpa ekitatipa ishmukas mɨjatpa karakas esfuesu mɨjatpa wat wanmaktawa
+izan pialkas tɨntaruskasa paranitpai pais kas nit ɨn pialkasa auruspa tGamtuspa
+mɨnkas kasaptachiwa punfan tuan anna ɨn paittaruskasa.</para>
    </article>
    <article number="23">
       <title>Artikulu paz kutfia</title>
       <orderedlist>
          <listitem>
-            <para>Maza. Wantus wawaruskasa nit m+jan karakas wat kalkin wanturuskasa an
-kaltus wat puran chikas kitchiwa watsalmin kalkitpa anna +n sun kaltus watmin
-+m+shna.</para>
+            <para>Maza. Wantus wawaruskasa nit mɨjan karakas wat kalkin wanturuskasa an
+kaltus wat puran chikas kitchiwa watsalmin kalkitpa anna ɨn sun kaltus watmin
+ɨmɨshna.</para>
          </listitem>
          <listitem>
-            <para>Paz. Wantus awarusmin nit +tpamai an kaltus watkimain mamas kawarain
-kalkitpa kawuarain m+ltawamakpaz</para>
+            <para>Paz. Wantus awarusmin nit ɨtpamai an kaltus watkimain mamas kawarain
+kalkitpa kawuarain mɨltawamakpaz</para>
          </listitem>
          <listitem>
-            <para>Maza. Wantusmin awarusne nit +tpa an kalne nit chatpa masa kaltus
-renumeracionkitpa p+na watmin kara nitchatpai wan kualtuskasa masa wat
+            <para>Maza. Wantusmin awarusne nit ɨtpa an kalne nit chatpa masa kaltus
+renumeracionkitpa pɨna watmin kara nitchatpai wan kualtuskasa masa wat
 puran chikas kitchiwal humanakas katmizna wal puran.</para>
          </listitem>
          <listitem>
-            <para>Paz. Wantus awain nit +n au chiwasha kaltus wat kuintakitpa an kalne
-wanmaktawai pailtaruskasa kara t+ntaruzkasa wat nit +tpamak'paz,</para>
+            <para>Paz. Wantus awain nit ɨn au chiwasha kaltus wat kuintakitpa an kalne
+wanmaktawai pailtaruskasa kara tɨntaruzkasa wat nit ɨtpamak'paz,</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="24">
       <title>Artikulu paz ampara</title>
-      <para>Wantuz awarus nit +tpamai karakaz kuaishkultawai mamaz sairawai mamaz kal
+      <para>Wantuz awarus nit ɨtpamai karakaz kuaishkultawai mamaz sairawai mamaz kal
 akuan payu chatpa ishtawai mamaz kal akuan kalkitpa pakacionkaz periutikaz
-p+ntit</para>
+pɨntit</para>
    </article>
    <article number="25">
       <title>Artikulu paz shish</title>
       <orderedlist>
          <listitem>
-            <para>Maza . wantLJZPé:l ëlwaruz nit m+jatpa auruzpakai au tuamtuspa an tuan
+            <para>Maza . wantLJZPé:l ëlwaruz nit mɨjatpa auruzpakai au tuamtuspa an tuan
 watpuran kupairuzkasa karakaz kualtuskaz imtukitchin puran pienestarkas
 wasalmin kumira pin wat tuan wasan istukika paitta serpiciukas social kas
-pachimtumakpaz wan nit +npa karakaz wan nit m+jatpa paitakalkaz ishmukaz
-piotakaz +Iapakaz mamazkaz kar+tkaz SUr] kar+kaz kuailkir+ka chi.wacha
-m+janne chiwacha pialm+jatpa.</para>
+pachimtumakpaz wan nit ɨnpa karakaz wan nit mɨjatpa paitakalkaz ishmukaz
+piotakaz ɨIapakaz mamazkaz karɨtkaz SUr] karɨkaz kuailkirɨka chi.wacha
+mɨjanne chiwacha pialmɨjatpa.</para>
          </listitem>
          <listitem>
-            <para>Maza .sun maternitakaz sun nit +tpamai kuirakitpa un Chat ashpa wan
-. paishparusa chiktaruz kasakitpa uspane wan nit +tpamai sun kaltus.</para>
+            <para>Maza .sun maternitakaz sun nit ɨtpamai kuirakitpa un Chat ashpa wan
+. paishparusa chiktaruz kasakitpa uspane wan nit ɨtpamai sun kaltus.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -291,20 +291,20 @@ m+janne chiwacha pialm+jatpa.</para>
       <title>Artikulu paz wak</title>
       <orderedlist>
          <listitem>
-            <para>Maza. Wan awarusne nit chatpamai an p+nk+h kamnu yalta karakaz muinchi
-kainm+lkamtui an p+nk+h kammuruzne pialchi kain kar:ntumai masantuzne</para>
+            <para>Maza. Wan awarusne nit chatpamai an pɨnkɨh kamnu yalta karakaz muinchi
+kainmɨlkamtui an pɨnkɨh kammuruzne pialchi kain kar:ntumai masantuzne</para>
          </listitem>
          <listitem>
-            <para>Paz. p+nk+h kammu sarawa t+kaza sunkana kamchan awaruzkasa wanmakkit
-anFia +mizna chikazkiztachiwa nitsar+tne awarusa watpuran minpa ainjtaz
-kaiwaintawamakpaz wàn m+tchatpa kupairu m+jatpa mamaz suraz wantuz
-wanmakchatpa mamaz kualkasakaz chachikitpa anna m+lmizna sunkal
+            <para>Paz. pɨnkɨh kammu sarawa tɨkaza sunkana kamchan awaruzkasa wanmakkit
+anFia ɨmizna chikazkiztachiwa nitsarɨtne awarusa watpuran minpa ainjtaz
+kaiwaintawamakpaz wàn mɨtchatpa kupairu mɨjatpa mamaz suraz wantuz
+wanmakchatpa mamaz kualkasakaz chachikitpa anna mɨlmizna sunkal
 sukazakaz kuirakitpamakpaz watpuran.</para>
          </listitem>
          <listitem>
-            <para>Karakaz wat p+nk+h kammu yal m+jatpamakpaz au nit +m+shna wantaruskaza
-Wantus nit m+jmakpaz karane chiktamakpaz au nit +m+shna au sura wantusa
-wanmakt+t puratpamakpaz au mi wat nit +m+zhna</para>
+            <para>Karakaz wat pɨnkɨh kammu yal mɨjatpamakpaz au nit ɨmɨshna wantaruskaza
+Wantus nit mɨjmakpaz karane chiktamakpaz au nit ɨmɨshna au sura wantusa
+wanmaktɨt puratpamakpaz au mi wat nit ɨmɨzhna</para>
          </listitem>
       </orderedlist>
    </article>
@@ -312,49 +312,49 @@ wanmakt+t puratpamakpaz au mi wat nit +m+zhna</para>
       <title>Artikulu paz ita</title>
       <orderedlist>
          <listitem>
-            <para>Kutna. Karakaz paishtuzkaz m+jashinamai nit puran sairawa mamaz tuntu
-p+nk+h kammu washinai m+lashina up painkultusa</para>
+            <para>Kutna. Karakaz paishtuzkaz mɨjashinamai nit puran sairawa mamaz tuntu
+pɨnkɨh kammu washinai mɨlashina up painkultusa</para>
          </listitem>
          <listitem>
-            <para>Wantus awarus nit chatpa an kuintakintpa m+nakaz kaishaptachiwain m+nkaz
-uzpain masain chanapa p+p+lusane apkultura awane kapumakpaz
-wanmakt+tpuramakpaz aune +tpamakpaz wanmakna usparuskasa an kaltus
-produccionkaz cientifikukaz chiwachakaz sunkalne m+jatpa.</para>
+            <para>Wantus awarus nit chatpa an kuintakintpa mɨnakaz kaishaptachiwain mɨnkaz
+uzpain masain chanapa pɨpɨlusane apkultura awane kapumakpaz
+wanmaktɨtpuramakpaz aune ɨtpamakpaz wanmakna usparuskasa an kaltus
+produccionkaz cientifikukaz chiwachakaz sunkalne mɨjatpa.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="28">
       <title>Artikulu paz tuil. wantuzka</title>
-      <para>M+jmakpaz nit+m+shna sunkal katmishna wat kalkinpa makpaz karakaz wat
-nitm+jan anne intenacionalkaz uspakaz nit m+jmaim+nminkaz kashamuchi
+      <para>Mɨjmakpaz nitɨmɨshna sunkal katmishna wat kalkinpa makpaz karakaz wat
+nitmɨjan anne intenacionalkaz uspakaz nit mɨjmaimɨnminkaz kashamuchi
 atchan nit sana suazne sarawai nitpara wattan.</para>
    </article>
    <article number="29">
       <title>Artikulo paz pikam</title>
       <orderedlist>
          <listitem>
-            <para>Maza. Wan awaruz wattchatpamakpas p+p+rura uzpain kêiikishinamai wankal
+            <para>Maza. Wan awaruz wattchatpamakpas pɨpɨrura uzpain kêiikishinamai wankal
 piankamchan</para>
          </listitem>
          <listitem>
-            <para>Paz.pakamchamizna an nit m+ntatchan m+nkazkachatmuchi wan awaruz
-uzparuzpain satkitt+p+nk+h samsatm+lmizna p+nk+h t+nta sunkana
-satm+ltawamakpaz wail piankamchan chikaz kaizchatchiwa sunkana nitsar+t
-m+jne watpuran mamazkazaruzkaz aishtaiz kizna pichipmin wayaiz nukulmizna
+            <para>Paz.pakamchamizna an nit mɨntatchan mɨnkazkachatmuchi wan awaruz
+uzparuzpain satkittɨpɨnkɨh samsatmɨlmizna pɨnkɨh tɨnta sunkana
+satmɨltawamakpaz wail piankamchan chikaz kaizchatchiwa sunkana nitsarɨt
+mɨjne watpuran mamazkazaruzkaz aishtaiz kizna pichipmin wayaiz nukulmizna
 wait minmisnane kuitkizmiznane wantuz purakin pana tuntu minkit
-satm+lmizna.</para>
+satmɨlmizna.</para>
          </listitem>
          <listitem>
-            <para>Maza wantuz nitsar+tne m+nkachapmuchi p+r+chimai maintazne sar+tt+
-uzt+t+ masain kazchan mamaz su.raz kaizta.</para>
+            <para>Maza wantuz nitsarɨtne mɨnkachapmuchi pɨrɨchimai maintazne sarɨttɨ
+uztɨtɨ masain kazchan mamaz su.raz kaizta.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="30">
       <title>Artikulo kutfia chalkuil</title>
-      <para>Ankara sar+tne nitpuzpuztutne sashina kaizkuintakitpa sunkanawasha mintu
-maztus' sùraz maza kual wanmakt+t maza awara suna putnainmizna
+      <para>Ankara sarɨtne nitpuzpuztutne sashina kaizkuintakitpa sunkanawasha mintu
+maztus' sùraz maza kual wanmaktɨt maza awara suna putnainmizna
 wankammizna kalkittaizpa chine samizna wankal wan nitpuzna chiwashza
-nitpuzt+ttne watchan nitpuzt+kane puzt+m.</para>
+nitpuztɨttne watchan nitpuztɨkane puztɨm.</para>
    </article>
 </udhr>


### PR DESCRIPTION
In practice + (as in OHCHR UDHR [PDF](https://www.ohchr.org/en/human-rights/universal-declaration/translations/awapit)) or formatted `<s>i</s>` are often used instead of ɨ.

For example:
- *La Constitución de 1991 y la Corte Constitucional: Awapit*, Corte Constitucional, República de Colombia, 2021 ([PDF](https://derechosenelterritorio.com/wp-content/uploads/2021/02/corte-awapit.pdf))
- *Consulta Previa SU-123-2018: Awapit*, Corte Constitucional,  República de Colombia, 2021 ([PDF](https://derechosenelterritorio.com/wp-content/uploads/2021/02/su123-awapit.pdf))
- *Awá karɨt puraruza wamkit saiwaimtu puramtuzkasa karain wan attɨm sukin puramtuzkasa kuinta kimtu puran*, 2020 ([PDF](https://web.archive.org/web/20240422041625/https://unidadbusqueda.gov.co/wp-content/uploads/2021/10/CARTILLA-AWA-PROTOCOLO-DE-RELACIONAMIENTO-UBPD.pdf))
- *9 Ap Kupairu Ihskairus: Awa , Guía para el Docente de EIFC*, Ministerio de Educación del Ecuador, 2018 ([PDF](https://educacion.gob.ec/wp-content/uploads/downloads/2019/09/Guia-del-docente-de-EIFC-Unidad-9-Awa.pdf))
- *10 Ap Ñanulas Piankamtu: Awa, Guía para el Docente de EIFC*, Ministerio de Educación del Ecuador, 2018 ([PDF](https://educacion.gob.ec/wp-content/uploads/downloads/2019/09/Guia-del-docente-de-EIFC-Unidad-10-Awa.pdf))
- *Kunpakakin*, Ministerio del Ambiente, Agua y Transición Ecologica, República del Ecuador, 2023 ([PDF](https://www.ambiente.gob.ec/wp-content/uploads/downloads/2023/03/3.-CONVOCATORIA-AWAPIT-AWA.pdf))

Colombia and Ecuador may use different alphabets, but both use ɨ.
The OHCHR translation ([PDF](http://documentacion.asambleanacional.gob.ec/alfresco/d/d/workspace/SpacesStore/3d47e30a-d8ef-47be-8c83-277661180bd5/VIRTUAL%20-%20001397.pdf)) was published in Ecuador.