### PR TITLE
[gkp] replace ĝ by ɠ

### DIFF
--- a/data/udhr/udhr_gkp.xml
+++ b/data/udhr/udhr_gkp.xml
@@ -6,11 +6,11 @@
     <title>Dɔn juwoo gbalatɔmaa</title>
     <para>A kɛ kaalonna da tɔɔi gaa nukan ɲei yɛnɛ yiihu diə lɛgbɔɔɓa laa, təlinmo laa da lilaa di nwundɔɔi.</para>
     <para>A kɛ lənɛɛ nukan dɔɔi gaa maanɛ yɛnɛ nuan diə pɛli kweiwoo ɓoi, diə laa di maamɛni la, yi di hwa kɛ ɲɛimaaɲɔn da mɔnɔ di hu, ɓə kele yɛnɛnuan kaa bɔi.</para>
-    <para>A kɛ tɔɔi gaa nukan ɲei yɛnɛyii hu ɓə maanɛ maa ə kɔnwɔ, hogɛ nukan hwəpa pənə hwə gwɛi təĝə hemɛi iɔi hu ɲɛitɔwɔnuan diə.</para>
-    <para>A kɛ lɔiŋaa kele yepuɔ gehu ɓə maanɛ gu hwaŋa tɛĝɛ bɔi.</para>
+    <para>A kɛ tɔɔi gaa nukan ɲei yɛnɛyii hu ɓə maanɛ maa ə kɔnwɔ, hogɛ nukan hwəpa pənə hwə gwɛi təɠə hemɛi iɔi hu ɲɛitɔwɔnuan diə.</para>
+    <para>A kɛ lɔiŋaa kele yepuɔ gehu ɓə maanɛ gu hwaŋa tɛɠɛ bɔi.</para>
     <para>A kɛ lɔi kele hu nuan ɓowoo ɓa, tɔɔi lele gaa hinaa di wɔɔ Kaalonnaa hu, yai a di wɔɔ tɛtɔwɔ yii lɛlɛ ɲɛikulo, yɛ pənə yɛ di wɔɔ yii ɲaanɛ lɛgbɔɔɓa laa hui.</para>
-    <para>A kɛ yɛnɛ lɔi kele da ŋɔɔ kpɔn gɛnɛi ɓə di liimu ə həĝə nɛgbɔɔɓa lelei da tɔɔi gaa ɲɛi yɛnɛ yii hu maa mɛni ɓai.</para>
-    <para>A kɛ giliɲahiə tɔnɔi ti hwilən nukan dɔɔi da ŋɔɔ lɛgbɔɔɓa laa ɓə gɛ, əlɛ yaɓə kɛ a di liimu həĝɛɛ a gbɔɔkpɔ, yili ɓə a gɛ lɔi kele diwɔɔ ɲaakpɔn gɛnɛ ə ɓo yɛnɛ.</para>
+    <para>A kɛ yɛnɛ lɔi kele da ŋɔɔ kpɔn gɛnɛi ɓə di liimu ə həɠə nɛgbɔɔɓa lelei da tɔɔi gaa ɲɛi yɛnɛ yii hu maa mɛni ɓai.</para>
+    <para>A kɛ giliɲahiə tɔnɔi ti hwilən nukan dɔɔi da ŋɔɔ lɛgbɔɔɓa laa ɓə gɛ, əlɛ yaɓə kɛ a di liimu həɠɛɛ a gbɔɔkpɔ, yili ɓə a gɛ lɔi kele diwɔɔ ɲaakpɔn gɛnɛ ə ɓo yɛnɛ.</para>
     <para>Maanɛ nutɛitɛi, ə makɛ a kpɔma yiŋaa di gɔl diə, maakwɛli, da hutɔ ɓə da nɛgbɔɔɓa, da tɔɔi gaa nukan ɲei yɛnɛyii hu di hee di kpanɲa kɛnaa kele ɓə, ə makɛ ɓɛyi ə wɔ ɲaawooɓo kaa lai, yili kele ɓə gɛi yɛnɛ bilibili gemɛi ŋɔ ɲaakpɔn gɛnɛi ɲɛi zea kaa Aməlik lɔi hui, ə dɔn ŋaa ɲɛi laa a pɔlɔ kpalaa ŋɔ holo pou (10) gwəlan nwaatɔnɔ pulu ŋun mɛinan yenan kɔu mɛihaaba (1948).</para>
   </preamble>
   <article number="1">
@@ -19,7 +19,7 @@
   </article>
   <article number="2">
     <title>Dɔn ŋoo veelɛ 2</title>
-    <para>Dɔn ɲɛi huwoo kaa nukele ɓa tanɔn, guloju hwə ma yɛ ə kɛ a huwu mɛni, gu kɔlɔ kɛpələ, gu lawoo, ɲaala mɛni kɛna bələ, kiliɲahie huwu lɔpe, nɛi hu yii ɓo pələ ɓa, hɛn jɔlɔɓo pələ pɔ da nukaapələ da zəĝei, yɛ ə kɛ a hulonu da nɛnu yilipulu, yɛ ə kɛ lɔi gaa gbɔɔɓa ju mun, yɛ ə kɛ a lɔi yi gaa nii məlan nɔi yemu a ju mun dɔn ɲɛi huwoo kaa nukele ɓa tanɔn.</para>
+    <para>Dɔn ɲɛi huwoo kaa nukele ɓa tanɔn, guloju hwə ma yɛ ə kɛ a huwu mɛni, gu kɔlɔ kɛpələ, gu lawoo, ɲaala mɛni kɛna bələ, kiliɲahie huwu lɔpe, nɛi hu yii ɓo pələ ɓa, hɛn jɔlɔɓo pələ pɔ da nukaapələ da zəɠei, yɛ ə kɛ a hulonu da nɛnu yilipulu, yɛ ə kɛ lɔi gaa gbɔɔɓa ju mun, yɛ ə kɛ a lɔi yi gaa nii məlan nɔi yemu a ju mun dɔn ɲɛi huwoo kaa nukele ɓa tanɔn.</para>
   </article>
   <article number="3">
     <title>Dɔn ŋoo zaaɓa 3</title>
@@ -27,7 +27,7 @@
   </article>
   <article number="4">
     <title>Dɔn ŋoo naan 4</title>
-    <para>Nuta hwa pɛli lɛɛi lualaa hu da tɔlaalaa hu, luolaa da luoyɔu huĝu lɔpe da kpɛ.</para>
+    <para>Nuta hwa pɛli lɛɛi lualaa hu da tɔlaalaa hu, luolaa da luoyɔu huɠu lɔpe da kpɛ.</para>
   </article>
   <article number="5">
     <title>Dɔn ŋoo nɔɔli 5</title>
@@ -43,7 +43,7 @@
   </article>
   <article number="8">
     <title>Dɔn ŋoo mɛihaaɓa 8</title>
-    <para>Maala kaa nukele yei ə li kititəĝə pɛlɛ la; a gaa yɛ maamɛni yɛ ə piliju.</para>
+    <para>Maala kaa nukele yei ə li kititəɠə pɛlɛ la; a gaa yɛ maamɛni yɛ ə piliju.</para>
   </article>
   <article number="9">
     <title>Dɔn ŋoo mɛinaan 9</title>
@@ -51,7 +51,7 @@
   </article>
   <article number="10">
     <title>Dɔn ŋoo bou 10</title>
-    <para>Maala ka nukele yei, ə ŋɔɔ tian makɔŋɔ kititə ĝə pɛlɛla, əlɛ dian ti ə kɛ a kɔlɔn ŋaa ə makɛ mɛni lɔpee daa zenwuɔn.</para>
+    <para>Maala ka nukele yei, ə ŋɔɔ tian makɔŋɔ kititə ɠə pɛlɛla, əlɛ dian ti ə kɛ a kɔlɔn ŋaa ə makɛ mɛni lɔpee daa zenwuɔn.</para>
   </article>
   <article number="11">
     <title>Dɔn ŋoo boukɔutanɔn 11</title>
@@ -86,7 +86,7 @@
 	<para>Nui lɔpe da ɲɛikɔu kpɔlu jeei, maala kaa ɲei ə maakilə lɔi takpɛli hu, yiyan nɔiti a pɛli ɲee hee mu.</para>
       </listitem>
       <listitem>
-	<para>Maakiləlaa ti hwa pɛli tɛĝɛi mɛni nɔŋɔn kɛmun gbɔɔkpɔ pɔ yi hwə ɓa lɔi ŋun ma mɛniɲɔŋɔn da kaala.</para>
+	<para>Maakiləlaa ti hwa pɛli tɛɠɛi mɛni nɔŋɔn kɛmun gbɔɔkpɔ pɔ yi hwə ɓa lɔi ŋun ma mɛniɲɔŋɔn da kaala.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -105,7 +105,7 @@
     <title>Dɔn ŋoo boukɔumɛida 16</title>
     <orderedlist>
       <listitem>
-	<para>Nɛɛnu da hulonu da həli kpilayela da di laŋayela da pɛli heei di kepɔ guloju hwə ma yɛkɛ la a huĝu mɛni, lɔilon na mɛni, əlɛ yala pələ mɛni. Di pɛliɛ a di ke ɲiiɓoo ti hu, ə makɛ di taĝai lowai.</para>
+	<para>Nɛɛnu da hulonu da həli kpilayela da di laŋayela da pɛli heei di kepɔ guloju hwə ma yɛkɛ la a huɠu mɛni, lɔilon na mɛni, əlɛ yala pələ mɛni. Di pɛliɛ a di ke ɲiiɓoo ti hu, ə makɛ di taɠai lowai.</para>
       </listitem>
       <listitem>
 	<para>Lɛgbɔɔɓa da laana ɓe a hilətai laa ma.</para>
@@ -152,7 +152,7 @@
 	<para>Maala kaa nukele yei, ə tɔɔi hɔlɔɓo ŋɔɔ lɔi ɲawooɓo mɛni hu, a wala kɛ a yaa kpinii, ə kɛ nui a ɲee lɛmai.</para>
       </listitem>
       <listitem>
-	<para>Maala kaa nukele yei, ə kolokɛ gahanama ɓa ŋɔɔ lɔi hu. Yiyan nuta hon bətlə hwa tɛĝɛ məlan ma.</para>
+	<para>Maala kaa nukele yei, ə kolokɛ gahanama ɓa ŋɔɔ lɔi hu. Yiyan nuta hon bətlə hwa tɛɠɛ məlan ma.</para>
       </listitem>
       <listitem>
 	<para>Lɔilonnii kiliɲahiə pələ ɓə lɔi ɲawoɓoɔ a kuloju. Giliɲahiə ti a kɔlɔn nɔi nɔi ɲaawoɓo nuan he luwai a kɛ a nɔi kwei nuan kəle laamaawoo.</para>


### PR DESCRIPTION
This replaces ĝ with ɠ in the Guinea Kpelle [gkp] translation because ɠ is correct character for the letter.
The 1976 Guinean national alphabet used gh and the 1989 Guinean national alpabet uses ɠ. The text is using ĝ as a substitute for ɠ.

See p. 6 of Marie Konoshenko, “Dictionnaire kpele de la Guinée (guerzé) – français”, Mandenkan, 62, 2019, pp. 3-164
https://llacan.cnrs.fr/PDF/Mandenkan62/62konoshenko.pdf
> "La consonne /ɣ/ est représentée par la lettre ɠ dans le dictionnaire
> conformément à l’orthographe moderne de la Guinée, [...]".

Note: In Liberia Kpelle (xpe) orthography, ɣ is used instead.