### PR TITLE
[shk] Fix typo in the article numbering within udhr_shk.xml

### DIFF
--- a/data/udhr/udhr_shk.xml
+++ b/data/udhr/udhr_shk.xml
@@ -229,7 +229,7 @@
       <title>Cigg 28</title>
       <para>Bëëd dhanhø e okorø yi cigg møg; gen a cigg-a ácïb ga møg ri gen bëëd yi pödhø kí bëëndøj geki pödhh-a kyeelø e da korri gïg-a dwaddi kipe døøji burø, ki täbbø, ni ka ácïb gen ceth ga møg mïdhi.</para>
    </article>
-   <article number="2">
+   <article number="29">
       <title>Cigg 29</title>
       <orderedlist>
          <listitem>


### PR DESCRIPTION
Minor correction -- "29" was mistranscribed as "2".